### PR TITLE
fix: Make launcher run AOE2 properly for Windows

### DIFF
--- a/lib/callhelper.py
+++ b/lib/callhelper.py
@@ -46,4 +46,7 @@ def runCommand(path, data):
     if "params" in executable:
         for index, param in enumerate(executable['params']):
             call.append(param)
-    subprocess.run(call, cwd=path, shell=True, check=True)
+    if runningLinux:
+        subprocess.run(call, cwd=path)
+    else:
+        subprocess.run(call, cwd=path, shell=True, check=True)

--- a/lib/callhelper.py
+++ b/lib/callhelper.py
@@ -46,4 +46,4 @@ def runCommand(path, data):
     if "params" in executable:
         for index, param in enumerate(executable['params']):
             call.append(param)
-    subprocess.run(call, cwd=path)
+    subprocess.run(call, cwd=path, shell=True, check=True)


### PR DESCRIPTION
Added back Shell=True, check=True to subprocess.run in callhelper.py